### PR TITLE
fix(swap): restore 30-minute Permit2 deadline for the token-B wrap

### DIFF
--- a/src/api/TransferBackendClient.ts
+++ b/src/api/TransferBackendClient.ts
@@ -14,6 +14,7 @@ import type {
   EstimateDurationResponse,
   NetworkConfigurationWrappedResponse,
   Permit2AllowanceResponse,
+  QuoteResponse,
   SendTransactionResponse,
   TransactionReceiptResponse,
   TransactionResultResponse,
@@ -75,6 +76,22 @@ export class TransferBackendClient extends ApiClient {
     parameters: Parameters
   ): Promise<EstimateDurationResponse> {
     return this.post(ApiPaths.EstimateDuration(network), parameters);
+  }
+
+  /**
+   * Fetches a Bebop swap quote via the backend proxy, which injects the
+   * `source-auth` token server-side. Returns Bebop's response verbatim.
+   */
+  async swapQuote(
+    network: string,
+    params: {
+      sellTokenAddress: Address;
+      buyTokenAddress: Address;
+      sellAmount: bigint;
+      genericForwarderAddress: Address;
+    }
+  ): Promise<QuoteResponse> {
+    return this.get<QuoteResponse>(ApiPaths.SwapQuote(network, params));
   }
 
   /**

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -19,6 +19,24 @@ export const ApiPaths = {
 
   EstimateDuration: (network: string) =>
     `/api/v1/transactions/${network}/estimate-duration`,
+
+  SwapQuote: (
+    network: string,
+    params: {
+      sellTokenAddress: string;
+      buyTokenAddress: string;
+      sellAmount: bigint;
+      genericForwarderAddress: string;
+    }
+  ) => {
+    const query = new URLSearchParams({
+      sell_token: params.sellTokenAddress,
+      buy_token: params.buyTokenAddress,
+      sell_amount: params.sellAmount.toString(),
+      taker_address: params.genericForwarderAddress,
+    });
+    return `/api/v1/swap/${network}/quote?${query.toString()}`;
+  },
   Health: "/health",
 } as const;
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -182,6 +182,8 @@ export type NetworkConfigurationResponse = {
   feeEncryptionPk: string;
   feeAuthorityPk: string;
   feeNullifierKeyCommitment: string;
+  genericCallForwarderAddress: string;
+  genericCallLogicVerifyingKey: string;
   tokens: Omit<TokenRegistry, "network">[];
 };
 
@@ -211,3 +213,42 @@ export type IndexerCheckKeysSyncResponse = Array<{
   chain_id: number;
   contract: string;
 }>;
+
+/**
+ * Bebop RFQ quote types. The quote is fetched server-side (so the `source-auth`
+ * token is never exposed to the browser) via `TransferBackendClient.swapQuote`,
+ * which returns Bebop's response verbatim — these types describe that shape.
+ */
+
+/** Per-token amount block in a Bebop quote (`amount`/`minimumAmount` are decimal strings of base units). */
+export type QuoteAmount = {
+  amount: string;
+  minimumAmount?: string;
+  decimals?: number;
+};
+
+/** Executable transaction returned when `gasless=false`. */
+export type QuoteTx = {
+  to: Address;
+  data: Hex;
+  value: string;
+  from?: Address;
+  gas?: number;
+  gasPrice?: number;
+};
+
+export type QuoteResponse = {
+  quoteId: string;
+  network: string;
+  expiry: number;
+  sellToken: Address;
+  buyToken: Address;
+  sellAmount: string;
+  buyAmount: string;
+  minBuyAmount: string;
+  approvalTarget: Address;
+  tx?: QuoteTx;
+  /** Contract that must be granted the sell-token approval. */
+  approvalType?: string;
+  error?: { errorCode?: number; message?: string };
+};

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -2,6 +2,8 @@ export * from "./history/services";
 export * from "./keys";
 export * from "./payroll";
 export * from "./resources";
+export * from "./transfer/genericCalls";
 export * from "./transfer/models";
 export * from "./transfer/services";
+export * from "./transfer/swapCalls";
 export * from "./transfer/types";

--- a/src/domain/transfer/genericCalls.ts
+++ b/src/domain/transfer/genericCalls.ts
@@ -1,0 +1,85 @@
+import { fromHex, toBase64 } from "lib/utils";
+import type { EvmCall, GenericCallInput } from "types";
+import { encodeAbiParameters, type Address, type Hex } from "viem";
+import { Digest, hashBytes, NullifierKey, randomBytes, Resource } from "wasm";
+
+/**
+ * ABI tuple for the `Call { address to; uint256 value; bytes data }` struct
+ * that the `GenericCallForwarder` decodes via `abi.decode(input, (Call[]))`.
+ */
+const CALL_ABI_PARAMETERS = [
+  {
+    type: "tuple[]",
+    components: [
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "data", type: "bytes" },
+    ],
+  },
+] as const;
+
+/**
+ * ABI-encodes `calls` as `Call[]`. This matches both the on-chain
+ * `abi.decode(input, (Call[]))` in `GenericCallForwarder.forwardCall` and the
+ * `Vec<Call>::abi_encode()` used by the witness library's `calculate_label_ref`,
+ * so the resulting `label_ref` agrees with the backend's logic proof.
+ */
+export function encodeGenericCalls(calls: EvmCall[]): Hex {
+  return encodeAbiParameters(CALL_ABI_PARAMETERS, [
+    calls.map(({ to, value, data }) => ({ to, value, data })),
+  ]);
+}
+
+/**
+ * Computes `label_ref = hash(forwarder_addr ‖ abi_encode(calls))`, the kind
+ * label for a generic-call resource.
+ */
+export function calculateGenericCallLabelRef(
+  forwarderAddress: Address,
+  calls: EvmCall[]
+): Digest {
+  const forwarderBytes = fromHex(forwarderAddress);
+  const callsBytes = fromHex(encodeGenericCalls(calls));
+  return hashBytes(new Uint8Array([...forwarderBytes, ...callsBytes]));
+}
+
+/**
+ * Serializes raw EVM calls into the backend witness shape, base64-encoding the
+ * calldata. `value` is narrowed to a JS number; swap calls always use 0 (wei),
+ * so no precision is lost.
+ */
+export function serializeGenericCalls(calls: EvmCall[]): GenericCallInput[] {
+  return calls.map(({ to, value, data }) => ({
+    to,
+    value: Number(value),
+    data: toBase64(fromHex(data)),
+  }));
+}
+
+/**
+ * Builds the ephemeral, quantity-0 generic-call resource that is consumed to
+ * carry the swap's EVM calls. Its `logic_ref` is the generic-call logic
+ * verifying key (from backend config) and its `label_ref` binds the forwarder
+ * and the exact calls. Defaults to the trivial nullifier key (the resource is
+ * unowned) and a random nonce to keep its nullifier unique within the tx.
+ */
+export function createGenericCallResource(params: {
+  logicVerifyingKey: string;
+  forwarderAddress: Address;
+  calls: EvmCall[];
+  nullifierKey?: NullifierKey;
+  nonce?: Digest;
+}): Resource {
+  const { logicVerifyingKey, forwarderAddress, calls } = params;
+  const nullifierKey = params.nullifierKey ?? NullifierKey.default();
+  const nonce = params.nonce ?? Digest.fromBytes(randomBytes());
+  return Resource.create(
+    Digest.fromHex(logicVerifyingKey),
+    calculateGenericCallLabelRef(forwarderAddress, calls),
+    0n,
+    Digest.default(),
+    true,
+    nonce,
+    nullifierKey.commit()
+  );
+}

--- a/src/domain/transfer/models/PayloadBuilder.ts
+++ b/src/domain/transfer/models/PayloadBuilder.ts
@@ -10,6 +10,7 @@ import type {
   ResolvedParameters,
 } from "types";
 import { PublicKey, type AuthoritySignature, type Digest } from "wasm";
+import { serializeGenericCalls } from "../genericCalls";
 import { authorizeActions } from "../services";
 
 const formatPayloadKey = (key: Uint8Array<ArrayBufferLike>) =>
@@ -60,7 +61,7 @@ export class PayloadBuilder {
           senderAuthorizationSignature:
             this.authorizationSignature ?
               toBase64(this.authorizationSignature.toBytes())
-            : "",
+              : "",
           senderAuthorizationVerifyingKey: formatPayloadKey(
             item.userPublicKeys.authorityPublicKey
           ),
@@ -84,6 +85,16 @@ export class PayloadBuilder {
           permit2Data: item.permit2Data,
           senderWalletAddress: item.address,
           tokenContractAddress: item.token.address,
+        },
+      };
+    }
+
+    // Generic-call resource carrying the swap's EVM calls (ex: Swap CU2)
+    if (item.type === "GenericCall") {
+      return {
+        GenericCallEphemeral: {
+          forwarderAddress: item.forwarderAddress,
+          calls: serializeGenericCalls(item.calls),
         },
       };
     }

--- a/src/domain/transfer/models/SwapResolver.ts
+++ b/src/domain/transfer/models/SwapResolver.ts
@@ -1,3 +1,4 @@
+import { SWAP_EXPIRATION_OFFSET_SECONDS } from "lib-constants";
 import { getUserPublicKeysFromKeyring } from "lib/keyUtils";
 import { toBase64 } from "lib/utils";
 import type {
@@ -75,7 +76,10 @@ export class SwapResolver {
   }
 
   /** Builds the intents for a given fee. Call repeatedly while converging on the fee. */
-  resolve(input: SwapResolveInput, expirationOffset = 60): ResolvedParameters {
+  resolve(
+    input: SwapResolveInput,
+    expirationOffset = SWAP_EXPIRATION_OFFSET_SECONDS
+  ): ResolvedParameters {
     const senderPublicKeys = getUserPublicKeysFromKeyring(this.senderKeyring);
     const nk = this.senderKeyring.nullifierKeyPair.nk;
 

--- a/src/domain/transfer/models/SwapResolver.ts
+++ b/src/domain/transfer/models/SwapResolver.ts
@@ -1,0 +1,171 @@
+import { getUserPublicKeysFromKeyring } from "lib/keyUtils";
+import { toBase64 } from "lib/utils";
+import type {
+  AppResource,
+  ConsumeIntent,
+  CreateIntent,
+  EvmCall,
+  Permit2Data,
+  ResolvedParameters,
+  SupportedChainConfig,
+  TokenRegistry,
+  UserKeyring,
+} from "types";
+import { NullifierKey, randomBytes } from "wasm";
+import { createGenericCallResource } from "../genericCalls";
+import { ParametersDraftResolver } from "./ParametersDraftResolver";
+import type { TransferBuilder } from "./TransferBuilder";
+
+export type SwapResolveInput = {
+  /** The user's resources for the sell token. */
+  senderResources: AppResource[];
+  /** Sell token (owned by the user). */
+  tokenA: TokenRegistry;
+  /** Buy token (must be a supported, wrappable token). */
+  tokenB: TokenRegistry;
+  /** Amount of token A to swap, in its smallest unit (excludes fee). */
+  swapAmount: bigint;
+  /** Guaranteed minimum amount of token B from the Bebop quote. */
+  minBuyAmount: bigint;
+  /** The four EVM calls executed by the GenericCallForwarder (CU2). */
+  calls: EvmCall[];
+  /** Heliax fee in token A, in its smallest unit. */
+  fee: bigint;
+};
+
+/**
+ * Builds a dummy Permit2 payload for the token-B wrap in CU3. The funds are
+ * pulled from the GenericCallForwarder, which implements ERC-1271 and always
+ * returns the magic value, so the signature is never verified on-chain. The
+ * backend's structural checks still require a 65-byte signature, a non-empty
+ * nonce, and an unexpired deadline.
+ */
+function buildForwarderWrapPermit2(expirationOffset: number): Permit2Data {
+  const signature = new Uint8Array(65);
+  signature[64] = 27; // r = 0, s = 0, v = 27 — accepted via ERC-1271.
+  return {
+    deadline: Math.floor(Date.now() / 1000) + expirationOffset,
+    nonce: toBase64(randomBytes()),
+    signature: toBase64(signature),
+  };
+}
+
+/**
+ * Resolves the full set of consumed/created resource intents for a swap.
+ *
+ * The token-A leg (unwrap into the forwarder + Heliax fee + change) reuses the
+ * standard {@link ParametersDraftResolver}; the generic-call (CU2) and
+ * token-B wrap (CU3) legs are appended as additional balanced pairs. The
+ * resulting `ResolvedParameters` is fed to a `PayloadBuilder` to authorize and
+ * serialize into the backend `Parameters`.
+ */
+export class SwapResolver {
+  private readonly transferBuilder: TransferBuilder;
+  private readonly senderKeyring: UserKeyring;
+  private readonly chain: SupportedChainConfig;
+
+  constructor(
+    transferBuilder: TransferBuilder,
+    senderKeyring: UserKeyring,
+    chain: SupportedChainConfig
+  ) {
+    this.transferBuilder = transferBuilder;
+    this.senderKeyring = senderKeyring;
+    this.chain = chain;
+  }
+
+  /** Builds the intents for a given fee. Call repeatedly while converging on the fee. */
+  resolve(input: SwapResolveInput, expirationOffset = 60): ResolvedParameters {
+    const senderPublicKeys = getUserPublicKeysFromKeyring(this.senderKeyring);
+    const nk = this.senderKeyring.nullifierKeyPair.nk;
+
+    // CU1 + fee + change: unwrap token A into the forwarder, pay the Heliax fee,
+    // and return any remainder to the user. Resource selection, fee/change
+    // receivers and padding are all handled by the standard resolver.
+    const tokenAResolver = new ParametersDraftResolver(
+      this.transferBuilder,
+      senderPublicKeys,
+      nk,
+      this.chain
+    );
+    tokenAResolver.addReceiver({
+      type: "EvmAddress",
+      address: this.chain.genericCallForwarderAddress,
+      quantity: input.swapAmount,
+      token: input.tokenA,
+    });
+    if (input.fee > 0n) {
+      tokenAResolver.addReceiver({
+        type: "AnomaAddress",
+        userPublicKeys: this.chain.feePublicKeys,
+        quantity: input.fee,
+        token: input.tokenA,
+      });
+    }
+    const tokenALeg = tokenAResolver.build(input.senderResources);
+
+    // CU2: the generic-call resource carrying the swap calls, balanced by a
+    // padding resource.
+    const genericCallResource = createGenericCallResource({
+      logicVerifyingKey: this.chain.genericCallLogicVerifyingKey,
+      forwarderAddress: this.chain.genericCallForwarderAddress,
+      calls: input.calls,
+    });
+    const genericCallConsume: ConsumeIntent = {
+      type: "GenericCall",
+      forwarderAddress: this.chain.genericCallForwarderAddress,
+      calls: input.calls,
+      resource: genericCallResource,
+      nullifierKey: NullifierKey.default(),
+    };
+    const genericCallPadding: CreateIntent = {
+      resource: this.transferBuilder.client.createPaddingResource({
+        nullifierKey: NullifierKey.default(),
+        resource: genericCallResource,
+      }),
+      receiver: undefined,
+    };
+
+    // CU3: wrap token B out of the forwarder into a persistent resource owned by
+    // the user. Reuses the mint resource pair, with the forwarder as the
+    // "sender" (wallet) of the ephemeral wrap resource.
+    const { consumedResource, createdResource } =
+      this.transferBuilder.client.createMintResources({
+        userAddress: this.chain.genericCallForwarderAddress,
+        forwarderAddress: this.chain.forwarderAddress,
+        token: input.tokenB.address,
+        quantity: input.minBuyAmount,
+        keyring: this.senderKeyring,
+      });
+    const wrapConsume: ConsumeIntent = {
+      type: "EvmAddress",
+      address: this.chain.genericCallForwarderAddress,
+      permit2Data: buildForwarderWrapPermit2(expirationOffset),
+      resource: consumedResource,
+      nullifierKey: new NullifierKey(nk),
+      token: input.tokenB,
+    };
+    const persistentBCreate: CreateIntent = {
+      resource: createdResource,
+      receiver: {
+        type: "AnomaAddress",
+        userPublicKeys: senderPublicKeys,
+        quantity: input.minBuyAmount,
+        token: input.tokenB,
+      },
+    };
+
+    return {
+      consumeIntents: [
+        ...tokenALeg.consumeIntents,
+        genericCallConsume,
+        wrapConsume,
+      ],
+      createIntents: [
+        ...tokenALeg.createIntents,
+        genericCallPadding,
+        persistentBCreate,
+      ],
+    };
+  }
+}

--- a/src/domain/transfer/models/index.ts
+++ b/src/domain/transfer/models/index.ts
@@ -1,4 +1,5 @@
 export * from "./ParametersDraftResolver";
 export * from "./PayloadBuilder";
+export * from "./SwapResolver";
 export * from "./TransferBuilder";
 export * from "./TransferLogic";

--- a/src/domain/transfer/swapCalls.ts
+++ b/src/domain/transfer/swapCalls.ts
@@ -1,0 +1,69 @@
+import { PERMIT2_ADDRESS } from "@uniswap/permit2-sdk";
+import type { EvmCall } from "types";
+import { encodeFunctionData } from "viem";
+import type { SwapCall } from "./types/transfers";
+
+const ERC20_APPROVE_ABI = [
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "bool" }],
+  },
+] as const;
+
+/**
+ * Builds the three EVM calls executed by the GenericCallForwarder in the swap's
+ * CU2, using Bebop's "Standard" ERC-20 approval (the only approval type allowed
+ * for self-execution, i.e. `gasless=false`):
+ *
+ *  1. `tokenA.approve(approvalTarget, sellAmount)` — let the Bebop settlement
+ *     contract pull token A via `transferFrom`.
+ *  2. the Bebop swap transaction (`tx.to` / `tx.data`).
+ *  3. `tokenB.approve(Permit2, minBuyAmount)` — so the ERC20 forwarder can pull
+ *     token B from the forwarder via Permit2 when wrapping it in CU3.
+ *
+ * `approvalTarget` is the contract that pulls token A (from the Bebop quote);
+ * it defaults to the swap `tx.to`.
+ */
+export function buildSwapCalls({
+  tokenA,
+  tokenB,
+  sellAmount,
+  minBuyAmount,
+  txData,
+  destinationAddress,
+  txAmount,
+  approvalTarget,
+}: SwapCall): EvmCall[] {
+  const spender = approvalTarget ?? destinationAddress;
+  return [
+    {
+      to: tokenA,
+      value: 0n,
+      data: encodeFunctionData({
+        abi: ERC20_APPROVE_ABI,
+        functionName: "approve",
+        args: [spender, sellAmount],
+      }),
+    },
+    {
+      to: destinationAddress,
+      value: BigInt(txAmount || "0"),
+      data: txData,
+    },
+    {
+      to: tokenB,
+      value: 0n,
+      data: encodeFunctionData({
+        abi: ERC20_APPROVE_ABI,
+        functionName: "approve",
+        args: [PERMIT2_ADDRESS, minBuyAmount],
+      }),
+    },
+  ];
+}

--- a/src/domain/transfer/tests/swapResolver.test.ts
+++ b/src/domain/transfer/tests/swapResolver.test.ts
@@ -1,0 +1,110 @@
+import { SWAP_EXPIRATION_OFFSET_SECONDS } from "lib-constants";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// SwapResolver reaches into the wasm module for resource construction; the
+// deadline logic under test does not, so stub it out rather than initializing
+// WebAssembly.
+vi.mock("wasm", () => ({
+  Digest: { fromBytes: vi.fn(), fromHex: vi.fn(), default: vi.fn() },
+  Resource: { create: vi.fn(() => ({})) },
+  NullifierKey: class {
+    static default() {
+      return {};
+    }
+  },
+  hashBytes: vi.fn(() => ({})),
+  randomBytes: vi.fn(() => new Uint8Array(32)),
+}));
+
+vi.mock("../genericCalls", () => ({
+  createGenericCallResource: vi.fn(() => ({})),
+}));
+
+const addReceiver = vi.fn();
+const build = vi.fn(() => ({ consumeIntents: [], createIntents: [] }));
+vi.mock("../models/ParametersDraftResolver", () => ({
+  ParametersDraftResolver: class {
+    addReceiver = addReceiver;
+    build = build;
+  },
+}));
+
+vi.mock("lib/keyUtils", () => ({
+  getUserPublicKeysFromKeyring: vi.fn(() => ({})),
+}));
+
+const { SwapResolver } = await import("../models/SwapResolver");
+
+const chain = {
+  genericCallForwarderAddress: "0x4220bcb4a9c755aee676c675ccc8a113e2a48274",
+  forwarderAddress: "0x775c81a47f2618a8594a7a7f4a3df2a300337559",
+  genericCallLogicVerifyingKey: "00",
+  feePublicKeys: {},
+} as never;
+
+const keyring = { nullifierKeyPair: { nk: new Uint8Array(32) } } as never;
+
+const transferBuilder = {
+  client: {
+    createPaddingResource: vi.fn(() => ({})),
+    createMintResources: vi.fn(() => ({
+      consumedResource: {},
+      createdResource: {},
+    })),
+  },
+} as never;
+
+const input = {
+  senderResources: [],
+  tokenA: { address: "0xa", decimals: 6, symbol: "USDT" },
+  tokenB: { address: "0xb", decimals: 6, symbol: "USDC" },
+  swapAmount: 100_000n,
+  minBuyAmount: 98_916n,
+  calls: [],
+  fee: 1_000n,
+} as never;
+
+/** Pulls the token-B wrap's Permit2 deadline out of the resolved intents. */
+const resolvedDeadline = (offset?: number): number => {
+  const resolver = new SwapResolver(transferBuilder, keyring, chain);
+  const resolved =
+    offset === undefined ?
+      resolver.resolve(input)
+    : resolver.resolve(input, offset);
+  const wrap = resolved.consumeIntents.find(
+    (i: { permit2Data?: { deadline: number } }) => i.permit2Data !== undefined
+  ) as { permit2Data: { deadline: number } };
+  return wrap.permit2Data.deadline;
+};
+
+describe("SwapResolver token-B wrap Permit2 deadline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    build.mockReturnValue({ consumeIntents: [], createIntents: [] });
+  });
+
+  it("defaults to the 30-minute swap expiration window", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const deadline = resolvedDeadline();
+
+    expect(SWAP_EXPIRATION_OFFSET_SECONDS).toBe(30 * 60);
+    // Allow a couple of seconds of clock drift during the test.
+    expect(deadline).toBeGreaterThanOrEqual(now + SWAP_EXPIRATION_OFFSET_SECONDS - 2);
+    expect(deadline).toBeLessThanOrEqual(now + SWAP_EXPIRATION_OFFSET_SECONDS + 2);
+  });
+
+  it("leaves enough room to survive the review step", () => {
+    // The previous default was 60 seconds, which expired while the user was
+    // still on the review screen. The backend rejects an expired deadline at
+    // the API boundary, against wall-clock rather than chain time.
+    const now = Math.floor(Date.now() / 1000);
+    expect(resolvedDeadline()).toBeGreaterThan(now + 10 * 60);
+  });
+
+  it("still honours an explicit override", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const deadline = resolvedDeadline(120);
+    expect(deadline).toBeGreaterThanOrEqual(now + 118);
+    expect(deadline).toBeLessThanOrEqual(now + 122);
+  });
+});

--- a/src/domain/transfer/types/resources.ts
+++ b/src/domain/transfer/types/resources.ts
@@ -1,12 +1,23 @@
 import type { EncodedResource, MerkleTree, NullifierKey, Resource } from "wasm";
 
 import type { TokenRegistry, UserKeyring, UserPublicKeys } from "types";
-import type { Address } from "viem";
+import type { Address, Hex } from "viem";
 import type {
   ConsumedWitnessData,
   CreatedWitnessData,
   Permit2Data,
 } from "./witness";
+
+/**
+ * A raw EVM call forwarded through the GenericCallForwarder. Calldata is hex
+ * here (used to compute the resource `label_ref`); it is base64-encoded only
+ * when serialized into the backend witness (`GenericCallInput`).
+ */
+export type EvmCall = {
+  to: Address;
+  value: bigint;
+  data: Hex;
+};
 
 /**
  * Prop types for creating resources
@@ -64,13 +75,13 @@ export type Parameters = {
 
 export type Receiver = { token: TokenRegistry; quantity: bigint } & (
   | {
-      type: "AnomaAddress";
-      userPublicKeys: UserPublicKeys;
-    }
+    type: "AnomaAddress";
+    userPublicKeys: UserPublicKeys;
+  }
   | {
-      type: "EvmAddress";
-      address: Address;
-    }
+    type: "EvmAddress";
+    address: Address;
+  }
 );
 
 export type ConsumeIntent = {
@@ -78,19 +89,24 @@ export type ConsumeIntent = {
   nullifierKey: NullifierKey;
   token?: TokenRegistry;
 } & (
-  | {
+    | {
       type: "AnomaAddress";
       userPublicKeys: UserPublicKeys;
     }
-  | {
+    | {
       type: "EvmAddress";
       address: Address;
       permit2Data: Permit2Data;
     }
-  | {
+    | {
       type: "Padding";
     }
-);
+    | {
+      type: "GenericCall";
+      forwarderAddress: Address;
+      calls: EvmCall[];
+    }
+  );
 
 export type CreateIntent = {
   resource: Resource;

--- a/src/domain/transfer/types/transfers.ts
+++ b/src/domain/transfer/types/transfers.ts
@@ -1,0 +1,12 @@
+import { type Address, type Hex } from "viem";
+
+export type SwapCall = {
+  tokenA: Address;
+  tokenB: Address;
+  sellAmount: bigint;
+  minBuyAmount: bigint;
+  txData: Hex;
+  destinationAddress: Address;
+  txAmount?: bigint;
+  approvalTarget?: Address;
+};

--- a/src/domain/transfer/types/witness.ts
+++ b/src/domain/transfer/types/witness.ts
@@ -46,6 +46,25 @@ type TokenTransferConsumedPersistent = {
   senderEncryptionPublicKey: string;
 };
 
+/**
+ * GENERIC CALL WITNESS DATA
+ */
+// `generic_call::CallInput` — a single EVM call forwarded through the
+// `GenericCallForwarder`. `data` is base64-encoded calldata (the backend
+// decodes it as `Vec<u8>`); `value` is wei sent with the call (0 for ERC-20 swaps).
+export type GenericCallInput = {
+  to: Address;
+  value: number;
+  data: string;
+};
+
+// `generic_call::ConsumedEphemeral` and `generic_call::CreatedEphemeral` share
+// this shape: the forwarder address (forms `label_ref`) plus the calls to run.
+type GenericCallEphemeral = {
+  forwarderAddress: Address;
+  calls: GenericCallInput[];
+};
+
 //************************************************************************
 // RESOURCES
 //************************************************************************
@@ -62,16 +81,23 @@ type TokenTransfer = {
   ConsumedPersistent: TokenTransferConsumedPersistent;
 };
 
+type GenericCall = {
+  CreatedEphemeral: GenericCallEphemeral;
+  ConsumedEphemeral: GenericCallEphemeral;
+};
+
 type CreatedWitnessDataEnum = {
   TokenTransferPersistent: TokenTransfer["CreatedPersistent"];
   TokenTransferEphemeralUnwrap: TokenTransfer["CreatedEphemeralUnwrap"];
   TrivialEphemeral: Trivial["CreatedEphemeral"];
+  GenericCallEphemeral: GenericCall["CreatedEphemeral"];
 };
 
 type ConsumedWitnessDataEnum = {
   TokenTransferPersistent: TokenTransfer["ConsumedPersistent"];
   TokenTransferEphemeralWrap: TokenTransfer["ConsumedEphemeralWrap"];
   TrivialEphemeral: Trivial["ConsumedEphemeral"];
+  GenericCallEphemeral: GenericCall["ConsumedEphemeral"];
 };
 
 //************************************************************************
@@ -83,6 +109,7 @@ export type CreatedWitnessDataSchema = {
   TokenTransferEphemeralUnwrap: CreatedWitnessDataEnum["TokenTransferEphemeralUnwrap"];
   TokenTransferPersistent: CreatedWitnessDataEnum["TokenTransferPersistent"];
   TrivialEphemeral: CreatedWitnessDataEnum["TrivialEphemeral"];
+  GenericCallEphemeral: CreatedWitnessDataEnum["GenericCallEphemeral"];
 };
 
 // Consumed Witness Data Schema
@@ -90,6 +117,7 @@ export type ConsumedWitnessDataSchema = {
   TokenTransferPersistent: ConsumedWitnessDataEnum["TokenTransferPersistent"];
   TokenTransferEphemeralWrap: ConsumedWitnessDataEnum["TokenTransferEphemeralWrap"];
   TrivialEphemeral: ConsumedWitnessDataEnum["TrivialEphemeral"];
+  GenericCallEphemeral: ConsumedWitnessDataEnum["GenericCallEphemeral"];
 };
 
 export type CreatedWitnessData = Partial<CreatedWitnessDataSchema>;

--- a/src/lib-constants.ts
+++ b/src/lib-constants.ts
@@ -42,6 +42,13 @@ export const MAX_DECIMALS = 6;
 // How long (ms) to wait for a Permit2 allowance transaction to be mined before timing out.
 export const permit2AllowanceTimeout = 60_000;
 
+// Validity window granted to the Permit2 payload authorizing a swap's token-B
+// wrap. Must cover the whole build → review → submit → validate path: the
+// backend rejects an expired deadline at the API boundary, and it checks it
+// against wall-clock time, not chain time. Matches
+// PERMIT2_DEADLINE_OFFSET_MILLISECONDS used by every other flow.
+export const SWAP_EXPIRATION_OFFSET_SECONDS = 30 * 60;
+
 // Changing this message will invalidate all existing keyrings, so be careful when modifying it.
 export const getSignMessage = (address: string) =>
   `I authorize AnomaPay to derive my account from address ${address}.\nDo NOT sign this message if the request url is not https://anomapay.app`;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,7 @@ import {
   formatUnits,
   hexToBytes,
   isAddress,
+  parseUnits,
   stringToBytes as viemStringToBytes,
   type Address,
   type Hex,
@@ -37,6 +38,19 @@ export const formatBalance = (
     minimumFractionDigits: decimals,
     maximumFractionDigits: tokenDenom,
   }).format(balance);
+};
+
+/** Parses a formatted amount, returning undefined for empty/invalid/zero input. */
+export const safeParseUnits = (
+  value: string,
+  decimals: number
+): bigint | undefined => {
+  try {
+    const parsed = parseUnits(value, decimals);
+    return parsed > 0n ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
 };
 
 /**


### PR DESCRIPTION
Targets `feat/swaps`, not `main` — stacks on the swap work in that branch.

**This is the one that unblocks the current failure.**

## Problem

`SwapResolver.resolve` took `expirationOffset = 60` as a default and is never
called with a second argument, so the Permit2 payload authorizing the token-B
wrap out of the GenericCallForwarder expires 60 seconds after the parameters are
built.

Every other flow uses `PERMIT2_DEADLINE_OFFSET_MILLISECONDS` (30 minutes), and
the prototype this was ported from used a named
`SWAP_EXPIRATION_OFFSET_SECONDS = 30 * 60` that became a bare `60` during the
port.

The window matters because the backend rejects an expired deadline at the API
boundary (`Permit2Data::validate`) against **wall-clock** time, not chain time —
and because swap parameters are now built at the Amount → Review transition,
leaving the user on the review screen while the 60 seconds elapse.

## Reproduction

Submitting the reported payload verbatim to a local backend:

```
Permit2 deadline has expired (deadline: 1784317579, now: 1784538078)   HTTP 400
```

Bumping **only** the deadline made the identical payload accepted (`202`), which
isolates this as the sole cause of that rejection.

## Tests

`swapResolver.test.ts` covers the window. Two of its three cases fail against
the previous bare `60`.

## Note on delivery

The app consumes the published SDK (`0.13.1`), so this needs an SDK release and
an app bump to actually reach users — it is not enough to merge this alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)