### PR TITLE
fix: static type check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 docs/
 *.tsbuildinfo
 .claude/
+.DS_Store
 
 # Ignore any local archives from npm pack
 *.tgz

--- a/src/api/TransferBackendClient.ts
+++ b/src/api/TransferBackendClient.ts
@@ -1,10 +1,10 @@
-import type { UUID } from "crypto";
 import type {
   FeeRequest,
   FeeResponse,
   Parameters,
   TokenBalancesResponse,
   TokenPriceResponse,
+  UUID,
 } from "types";
 import type { Address } from "viem";
 import { ApiClient } from "./ApiClient";

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -1,4 +1,4 @@
-import type { UUID } from "crypto";
+import type { UUID } from "types";
 
 export const ApiPaths = {
   Configuration: () => `/api/v1/configuration/all`,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,5 +1,4 @@
-import type { UUID } from "crypto";
-import type { TokenRegistry } from "types";
+import type { TokenRegistry, UUID } from "types";
 import type { Address, Hex } from "viem";
 
 // HTTP status codes we may want to check for

--- a/src/domain/resources/tests/services.test.ts
+++ b/src/domain/resources/tests/services.test.ts
@@ -1,8 +1,5 @@
-import type {
-  IndexerId,
-  NullifierRecord,
-  NullifyingTransactionsResponse,
-} from "api";
+import { parseNullifyingTransactions } from "api";
+import type { IndexerId, NullifierRecord } from "api";
 import type { SupportedChainConfig } from "types";
 import type { Address } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -28,17 +25,18 @@ const chain = {
 const nullifyingResponse = (
   nullifiers: { tag: string; txHash: string; timestamp: number }[],
   chainId = CHAIN_ID
-): NullifyingTransactionsResponse => [
-  {
-    chain_id: chainId,
-    contract_address: FORWARDER,
-    nullifiers: nullifiers.map(({ tag, txHash, timestamp }) => ({
-      tag: tag as Address,
-      transaction_hash: txHash as Address,
-      timestamp,
-    })),
-  },
-];
+): NullifierRecord[] =>
+  parseNullifyingTransactions([
+    {
+      chain_id: chainId,
+      contract_address: FORWARDER,
+      nullifiers: nullifiers.map(({ tag, txHash, timestamp }) => ({
+        tag: tag as Address,
+        transaction_hash: txHash as Address,
+        timestamp,
+      })),
+    },
+  ]);
 
 const optimisticRecord = (
   nullifier: string,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,7 +9,6 @@ import {
   type Address,
   type Hex,
 } from "viem";
-import z from "zod";
 
 export const shortenAddress = (address: string, head = 6, tail = 4) => {
   return `${address.slice(0, 2 + head)}…${address.slice(-tail)}`;
@@ -228,10 +227,6 @@ export const convertObjectToSnakeCase = (obj: object) => {
   }
   return output;
 };
-
-export const base64Schema = z
-  .base64()
-  .transform((val: string) => Buffer.from(val, "base64"));
 
 export function invariant(
   // eslint-disable-next-line

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,8 @@ export type Network = string;
 export type TokenId = `${string}:${string}`; // {network}:{symbol}
 export type NetworkAddress = `${Network}:${Address}`; // {network}:{address}
 
+export type UUID = `${string}-${string}-${string}-${string}-${string}`;
+
 export type AppResource = EncodedResource & {
   network: Network;
   erc20TokenAddress: Address;


### PR DESCRIPTION
Currently, we have three main errors while running `pnpm tsc`

This PR fixes this and you can run the `pnpm tsc` after that for a green state.

--- 

1. The tests were failing for the `NullifierRecord[]` type, which was updated on https://github.com/anoma/anoma-app-sdk/issues/21

<img width="662" height="232" alt="Screenshot 2026-07-21 at 13 12 18" src="https://github.com/user-attachments/assets/72d639b5-1e25-456e-ad2c-59ca79679391" />

--- 

2. The `Buffer.from()` is undefined on browser runtime environment. It could be replaced by the helper function `fromBase64()` but the `base64Schema` is a legacy code and it's not used in the app. We can safely delete it (also worth thinking if we should have `zod` at all in the sdk...)

<img width="1048" height="159" alt="Screenshot 2026-07-21 at 12 30 31" src="https://github.com/user-attachments/assets/52eee6b6-30d5-495a-82f8-285d4718c5cc" />

---
 
 3. The type `UUID`, which doesn't break on runtime since it's only a type, but will require the other projects that consumes the sdk to install the `@types/node` for this unique type case. The solution is just to create this type in the `types.ts` project

<img width="920" height="117" alt="Screenshot 2026-07-21 at 12 31 53" src="https://github.com/user-attachments/assets/60bf8c43-8c57-4bdd-b482-a3597a2974aa" />

