### PR TITLE
chore: add missing tslib dependency from permit2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+packageExtensionsChecksum: sha256-KBcmJXm2j/RsAMW1s20cYn2TiKmO59xmDBuLeuLYstg=
+
 importers:
 
   .:
@@ -3123,6 +3125,7 @@ snapshots:
     dependencies:
       ethers: 5.8.0
       tiny-invariant: 1.3.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4141,8 +4144,7 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ packages:
 
 allowBuilds:
   esbuild: false
+
+# permit2-sdk imports tslib without declaring it
+packageExtensions:
+  "@uniswap/permit2-sdk":
+    dependencies:
+      tslib: "^2.8.1"


### PR DESCRIPTION
`@uniswap/permit2-sdk` imports `tslib` at runtime (`import { __awaiter } from "tslib"`) but never declares it as a dependency. Under pnpm's isolated `node_modules` that package can only resolve its own declared deps, so bundling anything that pulls in the SDK — the `examples/balance` Vite build, for instance — fails with `Could not resolve "tslib"`. Adding `tslib` to the root package.json doesn't help, since the missing resolution happens inside permit2-sdk's own directory. This adds a pnpm `packageExtensions` entry in `pnpm-workspace.yaml` that patches the missing dependency onto `@uniswap/permit2-sdk`, so pnpm installs `tslib` where it's actually looked up. Fixes it once for every consumer rather than per-bundler workarounds.

<img width="953" height="267" alt="Screenshot 2026-08-05 at 17 03 18" src="https://github.com/user-attachments/assets/81afad5a-8665-4008-8a5a-4c219fba3838" />
